### PR TITLE
Use 'levelIndex' intermediate to calculate level stats, fixing off by 1

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -711,7 +711,8 @@ updateSize()
 function setup() {
 	const tileValues = [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
 	const toSet = [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24 ]
-	const levelStats = levels[level][Math.floor(Math.random() * 5)]
+	const levelIndex = Math.min(Math.max(level, 1), levels.length) - 1
+	const levelStats = levels[levelIndex][Math.floor(Math.random() * 5)]
 
 	copyMemoMode = false
 	sMemoButton.src = srcButtonMemoSOff

--- a/src/index.ts
+++ b/src/index.ts
@@ -711,8 +711,7 @@ updateSize()
 function setup() {
 	const tileValues = [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
 	const toSet = [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24 ]
-	const levelIndex = Math.min(Math.max(level, 1), levels.length) - 1
-	const levelStats = levels[levelIndex][Math.floor(Math.random() * 5)]
+	const levelStats = levels[level - 1][Math.floor(Math.random() * 5)]
 
 	copyMemoMode = false
 	sMemoButton.src = srcButtonMemoSOff


### PR DESCRIPTION
Hi there! Your app currently has an Off By 1 error that causes the game to crash when reaching level 8. The cleanest way I could find to repair this without rewriting every instance of you using the displayed "levelStats" to access something was to add a 1 line intermediary to switch the backend index by 1. I have also added a min/max clamp to prevent any accidental reintroduction of this bug from causing out of range crashes.

This fixes the crash when reaching level 8.